### PR TITLE
Scatter Shot for Hunters & two additonal toys for range checking

### DIFF
--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -215,8 +215,8 @@ local FriendItems  = {
   },
   [10] = {
     32321, -- Sparrowhawk Net
-  	166785, -- Detoxified Blight Grenade
-	  175063, -- Aqir Eqq Cluster
+    166785, -- Detoxified Blight Grenade
+    175063, -- Aqir Eqq Cluster
   },
   [15] = {
     1251, -- Linen Bandage
@@ -322,8 +322,8 @@ local HarmItems = {
   },
   [10] = {
     32321, -- Sparrowhawk Net
-   	166785, -- Detoxified Blight Grenade
-  	175063, -- Aqir Eqq Cluster
+    166785, -- Detoxified Blight Grenade
+    175063, -- Aqir Eqq Cluster
   },
   [15] = {
     33069, -- Sturdy Rope

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -112,7 +112,8 @@ HarmSpells["DRUID"] = {
 FriendSpells["HUNTER"] = {}
 HarmSpells["HUNTER"] = {
   75, -- ["Auto Shot"], -- 40
-  213691, -- ["Scatter Shot"], -- 20  
+  213691, -- ["Scatter Shot"], -- 20
+  257284, -- ["Hunter's Mark"] -- 60
 }
 
 FriendSpells["MAGE"] = {

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -112,6 +112,7 @@ HarmSpells["DRUID"] = {
 FriendSpells["HUNTER"] = {}
 HarmSpells["HUNTER"] = {
   75, -- ["Auto Shot"], -- 40
+  213691, -- ["Scatter Shot"], -- 20  
 }
 
 FriendSpells["MAGE"] = {
@@ -214,6 +215,8 @@ local FriendItems  = {
   },
   [10] = {
     32321, -- Sparrowhawk Net
+  	166785, -- Detoxified Blight Grenade
+	  175063, -- Aqir Eqq Cluster
   },
   [15] = {
     1251, -- Linen Bandage
@@ -319,6 +322,8 @@ local HarmItems = {
   },
   [10] = {
     32321, -- Sparrowhawk Net
+   	166785, -- Detoxified Blight Grenade
+  	175063, -- Aqir Eqq Cluster
   },
   [15] = {
     33069, -- Sturdy Rope


### PR DESCRIPTION
Added:\

1) Scatter Shot as a 20-year range check for Hunters (if talented)/ Works on my local copy correctly - if talented the 20-yard range check works, if not talented there's no 20-yard check, no obvious errors or error messages.

2) The new Hunter's Mark as a 60-yard range check. Tested & works on my local copy.

3) Two additional toys that may be able to be used as a 10-yard range check when Blizzard add-back the unfriendly item range checking as per recent Blue post - https://www.wowhead.com/news/restrictions-on-addon-range-checks-for-enemy-targets-being-reverted-in-future-336455 . Not tested currently in-combat.